### PR TITLE
Add special rule for sail

### DIFF
--- a/wechat/sharen
+++ b/wechat/sharen
@@ -1,5 +1,20 @@
 count=50
+sail=""
+
+if [[ $1 == "--sail" ]]; then
+  sail=$2
+  shift 2
+fi
+
 if [[ $1 != "" ]]; then
   count=$1
 fi
+
+if [[ -n "$sail" ]]; then
+  count=$(($count-1))
+fi
 python ./sharen.py $count
+if [[ -n "$sail" ]]; then
+  echo "Special rule for sail: kill $sail"
+fi
+


### PR DESCRIPTION
Add a special rule for killing sail, it works like this

```
$ ./sharen --sail 250 5

[ 1] count  27 ... ( 3 x+ 6 ) ... kill  27		[ 3] count 116 ... ( 16 x+ 4 ) ... kill 201		
[ 2] count  58 ... ( 8 x+ 2 ) ... kill  85		[ 4] count 222 ... ( 31 x+ 5 ) ... kill 423		



Special rule for sail: kill 250
```